### PR TITLE
Remove extra ')' from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export default {
       source2: 'data:application/pdf;base64,<BASE64_ENCODED_PDF>',
     }
   }
-})
+}
 </script>
 ```
 


### PR DESCRIPTION
The Usage example in the README.md file had an extra ')' character, which caused a syntax error when copy/pasting the code.