### PR TITLE
Added a "loaded" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ export default {
 | --------------------- | ----------------------------- | ------------------------------------------ |
 | internal-link-clicked | destination page number       | internal link was clicked                  |
 | loading-failed        | error object                  | failed to load document                    |
+| loaded                | PDF document proxy            | finished loading the document              |
 | password-requested    | callback function, retry flag | password is needed to display the document |
 | rendering-failed      | error object                  | failed to render document                  |
 | rendered              | –                             | finished rendering the document            |

--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -165,6 +165,7 @@ export default {
         }
         this.document = await documentLoadingTask.promise
         this.pageCount = this.document.numPages
+        this.$emit('loaded', this.document)
       } catch (e) {
         this.document = null
         this.pageCount = null


### PR DESCRIPTION
I added an event that's emited after a PDF file has finished loading. It returns the loaded PDF object so that it can be used outside the viewer, e.g. to read out annotations or to render page thumbnails (which is the use case I currently have).

I hope this is useful for other people as well.

Let me know if you need any changes.