### PR TITLE
Replaced multiple watchers with a single watcher.

### DIFF
--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -84,10 +84,7 @@ export default {
       pageNums: [],
     }
   },
-  async mounted() {
-    await this.load()
-    this.render()
-
+  created() {
     this.$watch(
       () => [
         this.source,
@@ -105,6 +102,10 @@ export default {
         this.render()
       }
     )
+  },
+  async mounted() {
+    await this.load()
+    this.render()
   },
   computed: {
     linkService() {

--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -84,6 +84,22 @@ export default {
       pageNums: [],
     }
   },
+  computed: {
+    linkService() {
+      if (!this.document || this.disableAnnotationLayer) {
+        return null
+      }
+
+      const service = new PDFLinkService()
+      service.setDocument(this.document)
+      service.setViewer({
+        scrollPageIntoView: ({ pageNumber }) => {
+          this.$emit('internal-link-clicked', pageNumber)
+        },
+      })
+      return service
+    },
+  },
   created() {
     this.$watch(
       () => [
@@ -106,22 +122,6 @@ export default {
   async mounted() {
     await this.load()
     this.render()
-  },
-  computed: {
-    linkService() {
-      if (!this.document || this.disableAnnotationLayer) {
-        return null
-      }
-
-      const service = new PDFLinkService()
-      service.setDocument(this.document)
-      service.setViewer({
-        scrollPageIntoView: ({ pageNumber }) => {
-          this.$emit('internal-link-clicked', pageNumber)
-        },
-      })
-      return service
-    },
   },
   methods: {
     /**

--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -84,6 +84,28 @@ export default {
       pageNums: [],
     }
   },
+  async mounted() {
+    await this.load()
+    this.render()
+
+    this.$watch(
+      () => [
+        this.source,
+        this.disableAnnotationLayer,
+        this.disableTextLayer,
+        this.height,
+        this.page,
+        this.rotation,
+        this.width,
+      ],
+      async ([newSource], [oldSource]) => {
+        if (newSource !== oldSource) {
+          await this.load()
+        }
+        this.render()
+      }
+    )
+  },
   computed: {
     linkService() {
       if (!this.document || this.disableAnnotationLayer) {
@@ -98,21 +120,6 @@ export default {
         },
       })
       return service
-    },
-    renderTrigger() {
-      return `${this.page}|${this.rotation}|${this.disableAnnotationLayer}|${this.disableTextLayer}|${this.width}|${this.height}`
-    },
-  },
-  watch: {
-    renderTrigger() {
-      this.render()
-    },
-    source: {
-      immediate: true,
-      async handler() {
-        await this.load()
-        this.render()
-      },
     },
   },
   methods: {

--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -99,18 +99,12 @@ export default {
       })
       return service
     },
+    renderTrigger() {
+      return `${this.page}|${this.rotation}|${this.disableAnnotationLayer}|${this.disableTextLayer}|${this.width}|${this.height}`
+    },
   },
   watch: {
-    disableAnnotationLayer() {
-      this.render()
-    },
-    disableTextLayer() {
-      this.render()
-    },
-    height() {
-      this.render()
-    },
-    page() {
+    renderTrigger() {
       this.render()
     },
     source: {
@@ -119,12 +113,6 @@ export default {
         await this.load()
         this.render()
       },
-    },
-    width() {
-      this.render()
-    },
-    rotation() {
-      this.render()
     },
   },
   methods: {


### PR DESCRIPTION
This prevents the render() method from being called multiple times in case several props are changed at the same time.
This is an alternative fix for #28.