### PR TITLE
Fixed loading the annotation icons

### DIFF
--- a/src/styles/annotation-layer.css
+++ b/src/styles/annotation-layer.css
@@ -27,7 +27,6 @@
 .annotationLayer .textAnnotation img {
   position: absolute;
   cursor: pointer;
-  opacity: 0;
 }
 
 .annotationLayer .popupWrapper {

--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -269,6 +269,7 @@ export default {
           .clone({
             dontFlip: true,
           }),
+          imageResourcesPath: '/node_modules/pdfjs-dist/web/images/',
       })
     },
     /**


### PR DESCRIPTION
Currently, the icons on the annotation layer fail to load. This change fixes this by setting the correct "imageResourcesPath"