### PR TITLE
Allow re-using the source between instances of the component

### DIFF
--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -157,20 +157,26 @@ export default {
         return
       }
 
-      try {
-        const documentLoadingTask = pdf.getDocument(this.source)
-        documentLoadingTask.onPassword = (callback, reason) => {
-          const retry = reason === pdf.PasswordResponses.INCORRECT_PASSWORD
-          this.$emit('password-requested', callback, retry)
-        }
-        this.document = await documentLoadingTask.promise
+      if (this.source instanceof Object && this.source.constructor.name === 'PDFDocumentProxy') {
+        this.document = this.source
         this.pageCount = this.document.numPages
         this.$emit('loaded', this.document)
-      } catch (e) {
-        this.document = null
-        this.pageCount = null
-        this.pageNums = []
-        this.$emit('loading-failed', e)
+      } else {
+        try {
+          const documentLoadingTask = pdf.getDocument(this.source)
+          documentLoadingTask.onPassword = (callback, reason) => {
+            const retry = reason === pdf.PasswordResponses.INCORRECT_PASSWORD
+            this.$emit('password-requested', callback, retry)
+          }
+          this.document = await documentLoadingTask.promise
+          this.pageCount = this.document.numPages
+          this.$emit('loaded', this.document)
+        } catch (e) {
+          this.document = null
+          this.pageCount = null
+          this.pageNums = []
+          this.$emit('loading-failed', e)
+        }
       }
     },
     /**


### PR DESCRIPTION
I changed the "source" property, so that a PdfDocumentProxy can be passed as a source. Those objects are emitted along with the "loaded" event. So using it can be as simple as this:

```
    <vue-pdf-embed :source="pdfSource" @loaded="(pdfDocumentProxy) => { this.pdfSource2 = pdfDocumentProxy}"/>
    <vue-pdf-embed :source="pdfSource2" v-if="pdfSource2" />
```

This fixes #24