### PR TITLE
Uptade README to add example for using public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ export default {
 | render | –                                                                            | manually (re)render document         |
 | print  | print resolution (`number`), filename (`string`), all pages flag (`boolean`) | print document via browser interface |
 
+**Note:** Public methods can be accessed via a [template ref](https://vuejs.org/guide/essentials/template-refs.html).
+
 ### Static Methods
 
 Besides the component itself, the module also includes a `getDocument` function for manual loading of PDF documents, which can then be used as the `source` prop of the component. In most cases it is sufficient to specify the `source` prop with a URL or typed array, while the result of the `getDocument` function can be used in special cases, such as sharing the source between multiple component instances. This is an advanced topic, so it is recommended to check the source code of the component before using this function.


### PR DESCRIPTION
Here's a small change to the README, with information on how to use a public method