### PR TITLE
V2: Add workerSrc prop for better CSP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export default {
 | annotationLayer    | `boolean`              | `true` or `false`                                          | whether the annotation layer should be enabled                             |
 | height             | `number` <br> `string` | natural numbers                                            | desired page height in pixels (ignored if the width property is specified) |
 | imageResourcesPath | `string`               | URL or path with trailing slash                            | path for icons used in the annotation layer                                |
+| workerSrc          | `string`               | URL                                                        | path for PDF worker script                                                 |
 | page               | `number` <br> `string` | `1` to the last page number                                | number of the page to display (displaying all pages if not specified)      |
 | rotation           | `number` <br> `string` | `0`, `90`, `180`, `270` (multiples of `90`)                | desired page rotation angle in degrees                                     |
 | scale              | `number`               | rational numbers                                           | desired ratio of canvas size to document size                              |

--- a/src/VuePdfEmbed.vue
+++ b/src/VuePdfEmbed.vue
@@ -60,6 +60,10 @@ const props = withDefaults(
      */
     imageResourcesPath?: string
     /**
+     * Path for worker script.
+     */
+    workerSrc?: string
+    /**
      * Number of the page to display.
      */
     page?: number | string
@@ -115,6 +119,7 @@ const { document } = useVuePdfEmbed({
     emit('progress', progressParams)
   },
   source: toRef(props, 'source'),
+  workerSrc: props.workerSrc,
 })
 
 const linkService = computed(() => {

--- a/src/composable.ts
+++ b/src/composable.ts
@@ -23,6 +23,7 @@ export function useVuePdfEmbed({
   onPasswordRequest,
   onProgress,
   source,
+  workerSrc,
 }: {
   onError?: (e: Error) => unknown
   onPasswordRequest?: (passwordRequestParams: {
@@ -34,6 +35,7 @@ export function useVuePdfEmbed({
     | ComputedRef<GetDocumentParameters | PDFDocumentProxy>
     | MaybeRef<GetDocumentParameters | PDFDocumentProxy>
     | ShallowRef<GetDocumentParameters | PDFDocumentProxy>
+  workerSrc?: string
 }) {
   const document = shallowRef<PDFDocumentProxy | null>(null)
   const documentLoadingTask = shallowRef<PDFDocumentLoadingTask | null>(null)
@@ -47,6 +49,9 @@ export function useVuePdfEmbed({
     }
 
     try {
+      if (workerSrc) {
+        pdf.GlobalWorkerOptions.workerSrc = workerSrc
+      }
       documentLoadingTask.value = pdf.getDocument(
         sourceValue as GetDocumentParameters
       )


### PR DESCRIPTION
Problem: 
Currently, the worker script is being loaded as a data: url. When CSP is limiting scripts, this will fail unless you enabled data: urls, which is strongly discouraged.

Fix:
Allow supplying a worker src in a prop. This allows using a url, and that url can be added to CSP in a strongly targeted matter. Note, however, that this likely only works if added to the first loaded component's props, and that the embedded script remains in the final Javascript as non-trivially sized dead code.