### PR TITLE
V2: Lint fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,12 @@
 {
+  "root": true,
   "extends": [
     "eslint:recommended",
     "plugin:vue/vue3-recommended",
     "@vue/typescript/recommended",
     "prettier"
   ],
+  "ignorePatterns": ["**/dist/**"],
   "parser": "vue-eslint-parser",
   "parserOptions": {
     "parser": "@typescript-eslint/parser",

--- a/src/VuePdfEmbed.vue
+++ b/src/VuePdfEmbed.vue
@@ -93,7 +93,10 @@ const emit = defineEmits<{
   (e: 'internal-link-clicked', value: number): void
   (e: 'loaded', value: PDFDocumentProxy): void
   (e: 'loading-failed', value: Error): void
-  (e: 'password-requested', value: { callback: Function; retry: boolean }): void
+  (
+    e: 'password-requested',
+    value: { callback: Function; isWrongPassword: boolean }
+  ): void
   (e: 'progress', value: OnProgressParameters): void
   (e: 'rendered'): void
   (e: 'rendering-failed', value: Error): void


### PR DESCRIPTION
~~Problem: The documentation (in README) and the implementation use isWrongPassword, but the emit spec uses retry
Fix: Make emit spec match documentation and implementation. Note, however, that this differs from V2.~~

Problem: Eslint checks dist, which likely fails eslint checks
Fix: Exclude dist from eslint

Problem: Nesting under a directory with existing eslint rules has interesting interactions
Fix: Add root to eslint config