### PR TITLE
fix: resolve bug where scaling factor causes the text and annotation layers to shift

### DIFF
--- a/src/VuePdfEmbed.vue
+++ b/src/VuePdfEmbed.vue
@@ -259,7 +259,7 @@ const render = async () => {
         const cssWidth = `${Math.floor(actualWidth)}px`
         const cssHeight = `${Math.floor(actualHeight)}px`
         const pageWidth = isTransposed ? page.view[3] : page.view[2]
-        const pageScale = props.scale ?? actualWidth / pageWidth
+        const pageScale = actualWidth / pageWidth
         const viewport = page.getViewport({
           scale: pageScale,
           rotation: pageRotation,
@@ -280,7 +280,7 @@ const render = async () => {
           div2.style.height = isTransposed ? cssWidth : cssHeight
         }
 
-        await renderPage(page, viewport, canvas)
+        await renderPage(page, viewport.clone({ scale: props.scale }), canvas)
 
         if (props.textLayer) {
           await renderPageTextLayer(

--- a/src/VuePdfEmbed.vue
+++ b/src/VuePdfEmbed.vue
@@ -65,6 +65,7 @@ const props = withDefaults(
   }>(),
   {
     rotation: 0,
+    scale: 1,
   }
 )
 
@@ -280,7 +281,13 @@ const render = async () => {
           div2.style.height = isTransposed ? cssWidth : cssHeight
         }
 
-        await renderPage(page, viewport.clone({ scale: props.scale }), canvas)
+        await renderPage(
+          page,
+          viewport.clone({
+            scale: viewport.scale * window.devicePixelRatio * props.scale,
+          }),
+          canvas
+        )
 
         if (props.textLayer) {
           await renderPageTextLayer(


### PR DESCRIPTION
Setting the `scale` prop causes the text and annotation layers to shift. This PR changes the behavior of `scale` to only scale the rendered PDF, keeping the correct positioning of the layers.

To decrease the amount of times the `scale` prop is required, the [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) is also added to the scaling of the rendered PDF. This ensures that PDFs will render crisply on retina and other high resolution displays by default.

Resolves #185 