### PR TITLE
Fix: Multiple blank pages when processing printed documents

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export function addPrintStyles(
   const style = iframe.contentWindow!.document.createElement('style')
   style.textContent = `
     @page {
-      margin: 0;
+      margin: 3mm;
       size: ${sizeX}pt ${sizeY}pt;
     }
     body {


### PR DESCRIPTION
Problem: When using the print function `print()`, multiple blank pages appear in the print preview screen.

Solution: Modify the value of the style attribute `margin` to `3mm` in the `addPrintStyles` function in the `src/utils.ts` file.

The reason is unknown, but presumably it may be related to the file itself, as some of the files do not have this problem.

Reference blog: <https://blog.csdn.net/qq_42249552/article/details/112860593>
The blog doesn't point out the reason for the blank page, it just states that the problem lies in the style. After several attempts, I changed the value of the `margin` property and solved the problem.

Solution #188 