### PR TITLE
Temporary fix for pdf.js vulnerability

### DIFF
--- a/src/VuePdfEmbed.vue
+++ b/src/VuePdfEmbed.vue
@@ -96,6 +96,7 @@ const { doc } = useVuePdfEmbed({
     emit('progress', progressParams)
   },
   source: toRef(props, 'source'),
+  isEvalSupported: false,
 })
 
 const linkService = computed(() => {


### PR DESCRIPTION
This fix sets `isEvalSupported = false` by default and passes the value to the getDocument function.

Based on https://github.com/mozilla/pdf.js/discussions/18168

```
... it's trivial to workaround the problem in older PDF.js versions simply by setting isEvalSupported: false in the getDocument-call.
```

Ideally this project can migrate to use the v4 of pdf.js but until then, this appears to be the easiest way to prevent the security issue by default, but it does not remove the vulnerability warning.