### PR TITLE
Fix: web worker is destroyed prematurely if `useVuePdfEmbed` is used

### DIFF
--- a/src/composables.ts
+++ b/src/composables.ts
@@ -17,6 +17,11 @@ import type {
 
 import type { PasswordRequestParams, Source } from './types'
 
+function isDocument(doc: MaybeRef<Source>) {
+  const docValue = toValue(doc)
+  return docValue && Object.prototype.hasOwnProperty.call(docValue, '_pdfInfo')
+}
+
 export function useVuePdfEmbed({
   onError,
   onPasswordRequest,
@@ -38,7 +43,7 @@ export function useVuePdfEmbed({
       return
     }
 
-    if (Object.prototype.hasOwnProperty.call(sourceValue, '_pdfInfo')) {
+    if (isDocument(sourceValue)) {
       doc.value = sourceValue as PDFDocumentProxy
       return
     }
@@ -90,7 +95,9 @@ export function useVuePdfEmbed({
       docLoadingTask.value.onProgress = null
     }
     docLoadingTask.value?.destroy()
-    doc.value?.destroy()
+    if (!isDocument(source)) {
+      doc.value?.destroy()
+    }
   })
 
   return {

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -9,6 +9,7 @@ import {
   type ShallowRef,
 } from 'vue'
 import { PasswordResponses, getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs'
+import { isDocument } from './utils'
 import type {
   OnProgressParameters,
   PDFDocumentLoadingTask,
@@ -16,11 +17,6 @@ import type {
 } from 'pdfjs-dist'
 
 import type { PasswordRequestParams, Source } from './types'
-
-function isDocument(doc: MaybeRef<Source>) {
-  const docValue = toValue(doc)
-  return docValue && Object.prototype.hasOwnProperty.call(docValue, '_pdfInfo')
-}
 
 export function useVuePdfEmbed({
   onError,
@@ -44,7 +40,7 @@ export function useVuePdfEmbed({
     }
 
     if (isDocument(sourceValue)) {
-      doc.value = sourceValue as PDFDocumentProxy
+      doc.value = sourceValue
       return
     }
 
@@ -95,7 +91,7 @@ export function useVuePdfEmbed({
       docLoadingTask.value.onProgress = null
     }
     docLoadingTask.value?.destroy()
-    if (!isDocument(source)) {
+    if (!isDocument(toValue(source))) {
       doc.value?.destroy()
     }
   })

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -9,7 +9,6 @@ import {
   type ShallowRef,
 } from 'vue'
 import { PasswordResponses, getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs'
-import { isDocument } from './utils'
 import type {
   OnProgressParameters,
   PDFDocumentLoadingTask,
@@ -17,6 +16,7 @@ import type {
 } from 'pdfjs-dist'
 
 import type { PasswordRequestParams, Source } from './types'
+import { isDocument } from './utils'
 
 export function useVuePdfEmbed({
   onError,
@@ -40,7 +40,7 @@ export function useVuePdfEmbed({
     }
 
     if (isDocument(sourceValue)) {
-      doc.value = sourceValue
+      doc.value = sourceValue as PDFDocumentProxy
       return
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,3 @@
-import type { Source } from './types'
-import type { PDFDocumentProxy } from 'pdfjs-dist'
-
 // @internal
 export function addPrintStyles(
   iframe: HTMLIFrameElement,
@@ -81,6 +78,6 @@ export function releaseChildCanvases(el?: HTMLElement | null) {
 }
 
 // @internal
-export function isDocument(document: Source): document is PDFDocumentProxy {
+export function isDocument(document: unknown) {
   return Object.prototype.hasOwnProperty.call(document, '_pdfInfo')
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import type { Source } from './types'
+import type { PDFDocumentProxy } from 'pdfjs-dist'
+
 // @internal
 export function addPrintStyles(
   iframe: HTMLIFrameElement,
@@ -75,4 +78,9 @@ export function releaseChildCanvases(el?: HTMLElement | null) {
     canvas.height = 1
     canvas.getContext('2d')?.clearRect(0, 0, 1, 1)
   })
+}
+
+// @internal
+export function isDocument(document: Source): document is PDFDocumentProxy {
+  return Object.prototype.hasOwnProperty.call(document, '_pdfInfo')
 }


### PR DESCRIPTION
`useVuePdfEmbed` destroys the corresponding web worker on unmount.
Because the `VuePdfEmbed` component uses this composable the web worker of a document is destoyed when the component is unmounted.

This behavior is fine until an external `useVuePdfEmbed` is used to load a document like [described here](https://github.com/hrynko/vue-pdf-embed?tab=readme-ov-file#document-loading).

Consider this example:
```ts
<script setup lang="ts">
import VuePdfEmbed from '../src/index'
import { useVuePdfEmbed } from '../src/index'
import { ref } from 'vue'

const pdfSource =
  'data:application/pdf;base64,' +
  'JVBERi0xLjcKCjEgMCBvYmogICUgZW50cnkgcG9pbnQKPDwKICAvVHlwZSAvQ2F0YWxv' +
  'ZwogIC9QYWdlcyAyIDAgUgo+PgplbmRvYmoKCjIgMCBvYmoKPDwKICAvVHlwZSAvUGFn' +
  'ZXMKICAvTWVkaWFCb3ggWyAwIDAgMjAwIDIwMCBdCiAgL0NvdW50IDEKICAvS2lkcyBb' +
  'IDMgMCBSIF0KPj4KZW5kb2JqCgozIDAgb2JqCjw8CiAgL1R5cGUgL1BhZ2UKICAvUGFy' +
  'ZW50IDIgMCBSCiAgL1Jlc291cmNlcyA8PAogICAgL0ZvbnQgPDwKICAgICAgL0YxIDQg' +
  'MCBSIAogICAgPj4KICA+PgogIC9Db250ZW50cyA1IDAgUgo+PgplbmRvYmoKCjQgMCBv' +
  'YmoKPDwKICAvVHlwZSAvRm9udAogIC9TdWJ0eXBlIC9UeXBlMQogIC9CYXNlRm9udCAv' +
  'VGltZXMtUm9tYW4KPj4KZW5kb2JqCgo1IDAgb2JqICAlIHBhZ2UgY29udGVudAo8PAog' +
  'IC9MZW5ndGggNDQKPj4Kc3RyZWFtCkJUCjcwIDUwIFRECi9GMSAxMiBUZgooSGVsbG8s' +
  'IHdvcmxkISkgVGoKRVQKZW5kc3RyZWFtCmVuZG9iagoKeHJlZgowIDYKMDAwMDAwMDAw' +
  'MCA2NTUzNSBmIAowMDAwMDAwMDEwIDAwMDAwIG4gCjAwMDAwMDAwNzkgMDAwMDAgbiAK' +
  'MDAwMDAwMDE3MyAwMDAwMCBuIAowMDAwMDAwMzAxIDAwMDAwIG4gCjAwMDAwMDAzODAg' +
  'MDAwMDAgbiAKdHJhaWxlcgo8PAogIC9TaXplIDYKICAvUm9vdCAxIDAgUgo+PgpzdGFy' +
  'dHhyZWYKNDkyCiUlRU9G'

const { doc } = useVuePdfEmbed({ source: pdfSource })

const enabled = ref(true)
</script>

<template>
  <input type="button" value="toggle" @click="enabled = !enabled" />
  <VuePdfEmbed v-if="enabled" :source="doc" />
</template>

```

If the button is pressed, the web worker is deleted. If it pressed again the document doesn't load anymore.

This PR fixes this behavior. The web worker is only unloaded if the composable did actually load the worker. If the document is already loaded from another composable the worker is not destroyed.