### PR TITLE
Upgrading pdfjs-dist to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "test": "jest",
     "lint": "eslint src demo --ext js,vue --fix"
   },
+  "dependencies": {
+    "pdfjs-dist": "^4.7.76"
+  },
   "devDependencies": {
     "@babel/core": "^7.14.2",
     "@babel/preset-env": "^7.14.2",
@@ -41,7 +44,6 @@
     "husky": "^8.0.0",
     "jest": "^26.6.3",
     "lint-staged": "^13.2.2",
-    "pdfjs-dist": "^2.9.359",
     "prettier": "^2.3.0",
     "sass": "^1.49.8",
     "sass-loader": "^12.6.0",


### PR DESCRIPTION
We are currently on the Vue2 version, and it seems to have `pdfjs-dist` in `devDependencies` as a blocker.

![Screenshot 2024-10-31 at 14 56 45](https://github.com/user-attachments/assets/df6d044f-c78c-40ca-92d5-fa4414f3ef9a)
