### PR TITLE
Add link service prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ const pdfSource = '<PDF_URL>'
 
 ### Props
 
-| Name               | Type                   | Accepted values                                         | Description                                                                |
-| ------------------ | ---------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------- |
-| annotationLayer    | `boolean`              | `true` or `false`                                       | whether the annotation layer should be enabled                             |
-| height             | `number`               | natural numbers                                         | desired page height in pixels (ignored if the width property is specified) |
-| imageResourcesPath | `string`               | URL or path with trailing slash                         | path for icons used in the annotation layer                                |
-| page               | `number`               | `1` to the last page number                             | number of the page to display (displaying all pages if not specified)      |
-| rotation           | `number`               | `0`, `90`, `180`, `270` (multiples of `90`)             | desired page rotation angle in degrees                                     |
-| scale              | `number`               | rational numbers                                        | desired page viewport scale                                                |
-| source             | `string` <br> `object` | document URL or Base64 or typed array or document proxy | source of the document to display                                          |
-| textLayer          | `boolean`              | `true` or `false`                                       | whether the text layer should be enabled                                   |
-| width              | `number`               | natural numbers                                         | desired page width in pixels                                               |
+| Name               | Type                                           | Accepted values                                         | Description                                                                                |
+| ------------------ | ---------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| annotationLayer    | `boolean`                                      |                                                         | whether the annotation layer should be enabled                                             |
+| height             | `number`                                       | natural numbers                                         | desired page height in pixels (ignored if the width property is specified)                 |
+| imageResourcesPath | `string`                                       | URL or path with trailing slash                         | path for icons used in the annotation layer                                                |
+| linkService        | `PDFLinkService`                               |                                                         | document navigation service to override the default one (emitting `internal-link-clicked`) |
+| page               | `number`                                       | `1` to the last page number                             | number of the page to display (displaying all pages if not specified)                      |
+| rotation           | `number`                                       | `0`, `90`, `180`, `270` (multiples of `90`)             | desired page rotation angle in degrees                                                     |
+| scale              | `number`                                       | rational numbers                                        | desired page viewport scale                                                                |
+| source             | `string` <br> `object` <br> `PDFDocumentProxy` | document URL or Base64 or typed array or document proxy | source of the document to display                                                          |
+| textLayer          | `boolean`                                      |                                                         | whether the text layer should be enabled                                                   |
+| width              | `number`                                       | natural numbers                                         | desired page width in pixels                                                               |
 
 ### Events
 

--- a/src/VuePdfEmbed.vue
+++ b/src/VuePdfEmbed.vue
@@ -39,6 +39,10 @@ const props = withDefaults(
      */
     imageResourcesPath?: string
     /**
+     * Document navigation service.
+     */
+    linkService?: PDFLinkService
+    /**
      * Number of the page to display.
      */
     page?: number
@@ -103,6 +107,8 @@ const { doc } = useVuePdfEmbed({
 const linkService = computed(() => {
   if (!doc.value || !props.annotationLayer) {
     return null
+  } else if (props.linkService) {
+    return props.linkService
   }
 
   const service = new PDFLinkService()


### PR DESCRIPTION
In this PR, I've introduced a `linkService` prop which can be used to override the default one that emits the `internal-link-clicked` event. @beliefgp and @AkromaPhage, would you mind taking a look to see if this meets your needs?

Resolves #193 and #246