### PR TITLE
fix: add endOfContent div to fix text selection issues

### DIFF
--- a/src/VuePdfEmbed.vue
+++ b/src/VuePdfEmbed.vue
@@ -301,6 +301,10 @@ const renderPageTextLayer = async (
     textContentSource: await page.getTextContent(),
     viewport,
   }).render()
+
+  const endOfContent = document.createElement('div')
+  endOfContent.className = 'endOfContent'
+  container.append(endOfContent)
 }
 
 watch(


### PR DESCRIPTION
I noticed, that the text selection in documents felt wrong in comparison to the pdf viewer in Firefox.
When dragging the selection over a part of the document with no text spans, the selection resets to the beginning of the page.

To avoid this behavior `pdf.js` in Firefox uses a hack that inserts a empty `div` behind the text that disables selections.

See here: https://github.com/mozilla/pdf.js/blob/b13ec1fc3c1ddee9f987f395b69195d9ad4c1ac9/web/text_layer_builder.js#L124-L127

The corresponding CSS class is already present in this library.
```css
.endOfContent {
  display: block;
  position: absolute;
  inset: 100% 0 0;
  z-index: 0;
  cursor: default;
  user-select: none;
}
```

So I only needed to port the logic, that adds the div behind the `TextLayer`.